### PR TITLE
Add Connection() method to the Client interface

### DIFF
--- a/client.go
+++ b/client.go
@@ -84,6 +84,8 @@ type Client interface {
 	ConnectedAt() time.Time
 	// DisconnectedAt return the disconnected time
 	DisconnectedAt() time.Time
+	// Connection returns the raw net.Conn
+	Connection() net.Conn
 	// Close closes the client connection. The returned channel will be closed after unregister process has been done
 	Close() <-chan struct{}
 
@@ -138,6 +140,11 @@ func (client *client) ConnectedAt() time.Time {
 // DisconnectedAt
 func (client *client) DisconnectedAt() time.Time {
 	return time.Unix(atomic.LoadInt64(&client.disconnectedAt), 0)
+}
+
+// Connection returns the raw net.Conn
+func (client *client) Connection() net.Conn {
+	return client.rwc
 }
 
 //OptionsReader returns the ClientOptionsReader. This is mainly used in callback functions.


### PR DESCRIPTION
Connection() returns raw net.Conn network connection. This makes it possible for plugins to access TLS credentials of a Client (by casting to a *tls.Conn), or to associate clients with the a connection from an OnAccept callback (which does not have a Client yet).

The use-case is like this: I'm using mutual tls (tls.RequireAndVerifyClientCert). Additionally I've implemented a plugin which uses information from the client certificate to chose a client policy (i.e. the topics a client is permitted to subscribe and/or publish to). 
