### PR TITLE
Fix 2 test cases that were comparing the same operands.

### DIFF
--- a/pkg/packets/packets_test.go
+++ b/pkg/packets/packets_test.go
@@ -36,7 +36,7 @@ func TestEncodeUTF8String(t *testing.T) {
 		if !bytes.Equal(b, v.wantBytes) {
 			t.Errorf("EncodeUTF8String(%v) error, want %v, but %v", v.buf, v.wantBytes, b)
 		}
-		if v.wantSize != v.wantSize {
+		if size != v.wantSize {
 			t.Errorf("EncodeUTF8String(%v) error, want %d, but %d", v.buf, v.wantSize, size)
 		}
 		if err != v.wantErr {
@@ -51,7 +51,7 @@ func TestDecodeUTF8String(t *testing.T) {
 		if !bytes.Equal(b, v.wantBytes) {
 			t.Errorf("DecodeUTF8String(%v) error, want %v, but %v", v.buf, v.wantBytes, b)
 		}
-		if v.wantSize != v.wantSize {
+		if size != v.wantSize {
 			t.Errorf("DecodeUTF8String(%v) error, want %d, but %d", v.buf, v.wantSize, size)
 		}
 		if err != v.wantErr {


### PR DESCRIPTION
Hey there!
I was scanning a bunch of Go code (https://semgrep.live/scan/94df082e-7ca1-4c1d-9b23-f229101aa7dc) and found this issue.
It looks like there were 2 test cases in `pkg/packets/packets_test.go` that were comparing `v.wantSize` on both sides, and it looks like the intention was to write `size != v.wantSize`.
This PR changes those. Hope it's helpful!