### PR TITLE
fix: segfault on arm due to unaligned atomics

### DIFF
--- a/client.go
+++ b/client.go
@@ -94,6 +94,12 @@ type Client interface {
 
 // Client represents a MQTT client and implements the Client interface
 type client struct {
+	// These two int64s must be at the top to guarantee they are 64bit aligned
+	// on 32bit architectures. If not then an attempt to store results in
+	// segfault. See: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	connectedAt    int64
+	disconnectedAt int64
+
 	server        *server
 	wg            sync.WaitGroup
 	rwc           net.Conn //raw tcp connection
@@ -114,9 +120,6 @@ type client struct {
 	//自定义数据
 	keys  map[string]interface{}
 	ready chan struct{} //close after session prepared
-
-	connectedAt    int64
-	disconnectedAt int64
 
 	statsManager SessionStatsManager
 }


### PR DESCRIPTION
This fixes the following segfault:

runtime/internal/atomic.goStore64(0x2487864, 0x5fc9a110, 0x0)
        /home/konrad/opt/go/src/runtime/internal/atomic/atomic_arm.go:144 +0x1c
github.com/DrmagicE/gmqtt.(*client).setDisconnectedAt(0x2487800, 0x184d7eef, 0xbfea8

The atomics must be 64bit aligned on 32bit architectures because
otherwise the attempt to store a value results in segfault.

See: https://golang.org/pkg/sync/atomic/#pkg-note-BUG