### PR TITLE
chore: warn log on conn lost

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -270,7 +270,7 @@ func (client *client) IsConnected() bool {
 func (client *client) setError(err error) {
 	client.errOnce.Do(func() {
 		if err != nil && err != io.EOF {
-			zaplog.Error("connection lost",
+			zaplog.Warn("connection lost",
 				zap.String("client_id", client.opts.ClientID),
 				zap.String("remote_addr", client.rwc.RemoteAddr().String()),
 				zap.Error(err))


### PR DESCRIPTION
First of all thank you so much for doing and sharing this MQTT 5 Server. :pray: 
At least in my initial searches, this was the only result of a Go(lang) based MQTT 5 Server.
And I'm planning to contribute to it in my following weeks and months.

---

I know it might be just a picky thing and maybe I'm used to see stack traces when something really bad or unknown happened (in which case a stack trace that should bring enough context details).

When I tested initially with a `paho.golag` client (which works just fine, btw, at least for now), in case of an authentication failure (either user doesn't exist or client provide wrong user credentials), the server (`gmqttd`) logs the error but also the stack trace. And that's defined on purpose in `config/config.go:237`) by:
`zaplog := zap.New(core, zap.AddStacktrace(zap.ErrorLevel), zap.AddCaller())`

Since to me it looks like something really bad happened.
![image](https://user-images.githubusercontent.com/14140226/182037701-63896f32-2d00-4e67-9006-309e77aa38fa.png)

And that's why I'm proposing this small change for now: a connection lost should be logged as warning.
Later, I would include one additional logging config item to specify at which level you'd like to have the stack trace included.
