### PR TITLE
Fixed memory leak when authentication is wrong

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -270,7 +270,7 @@ func (client *client) IsConnected() bool {
 func (client *client) setError(err error) {
 	client.errOnce.Do(func() {
 		if err != nil && err != io.EOF {
-			zaplog.Warn("FORKED connection lost",
+			zaplog.Warn("connection lost",
 				zap.String("client_id", client.opts.ClientID),
 				zap.String("remote_addr", client.rwc.RemoteAddr().String()),
 				zap.Error(err))

--- a/server/client.go
+++ b/server/client.go
@@ -1485,6 +1485,7 @@ func (client *client) serve() {
 
 	if client.err != nil {
 		client.Close()
+		fmt.Println("CLOSING CONNECTION")
 		return
 	}
 

--- a/server/client.go
+++ b/server/client.go
@@ -270,12 +270,12 @@ func (client *client) IsConnected() bool {
 func (client *client) setError(err error) {
 	client.errOnce.Do(func() {
 		if err != nil && err != io.EOF {
-			zaplog.Warn("connection lost",
+			zaplog.Warn("FORKED connection lost",
 				zap.String("client_id", client.opts.ClientID),
 				zap.String("remote_addr", client.rwc.RemoteAddr().String()),
 				zap.Error(err))
 			client.err = err
-			client.Close()
+			//client.Close()
 			if client.version == packets.Version5 {
 				if code, ok := err.(*codes.Error); ok {
 					if client.IsConnected() {
@@ -1472,6 +1472,10 @@ func (client *client) serve() {
 
 	}
 	readWg.Wait()
+
+	if client.err != nil {
+		client.Close()
+	}
 
 	if client.queueStore != nil {
 		qerr := client.queueStore.Close()

--- a/server/client.go
+++ b/server/client.go
@@ -1473,10 +1473,6 @@ func (client *client) serve() {
 	}
 	readWg.Wait()
 
-	if client.err != nil {
-		client.Close()
-	}
-
 	if client.queueStore != nil {
 		qerr := client.queueStore.Close()
 		if qerr != nil {
@@ -1486,6 +1482,12 @@ func (client *client) serve() {
 	if client.pl != nil {
 		client.pl.close()
 	}
+
+	if client.err != nil {
+		client.Close()
+		return
+	}
+
 	client.wg.Wait()
 	_ = client.rwc.Close()
 }

--- a/server/client.go
+++ b/server/client.go
@@ -1484,9 +1484,7 @@ func (client *client) serve() {
 	}
 
 	if client.err != nil {
-		client.Close()
-		fmt.Println("CLOSING CONNECTION")
-		return
+		close(client.close)
 	}
 
 	client.wg.Wait()

--- a/server/client.go
+++ b/server/client.go
@@ -275,6 +275,7 @@ func (client *client) setError(err error) {
 				zap.String("remote_addr", client.rwc.RemoteAddr().String()),
 				zap.Error(err))
 			client.err = err
+			client.Close()
 			if client.version == packets.Version5 {
 				if code, ok := err.(*codes.Error); ok {
 					if client.IsConnected() {


### PR DESCRIPTION
We had an mqtt client that was continously attempting to login with a wrong token into our broker and the memory usage was going up and up.

After digging into the problem, we found that after the connection was closed, two goroutines were still running: `writeLoop()` and `serve()`. `serve()` was blocked waiting for the closing of the `client.wg.Wait()`, and this wait group was still waiting for the `writeLoop()` to end. And the `writeLoop()` was blocked because it was waiting for the `client.close` channel. The defer in the `serve()` closed `client.closed`, but not `client.close`.

On this date, we still don't see the difference between `client.closed` and `client.close`, but closing `client.close` in case there is an error was necessary to end both go routines.

In any case, I am open to the discussion.

Thanks